### PR TITLE
Update Brick gem to v1.0.217

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.5)
+    public_suffix (5.1.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -297,7 +297,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.1.3p185
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.5.4


### PR DESCRIPTION
There was an inadvertent binding.pry left in The Brick gem in `v1.0.216`, and it is removed in this updated version.